### PR TITLE
Removed auto-commit to make async query sequences work better

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "homepage": "https://github.com/bminer/node-mysql-queues",
   "repository": {
     "type": "git",
-    "url": "git://github.com/bminer/node-mysql-queues.git"
+    "url": "git://github.com/myndzi/node-mysql-queues.git"
   },
   "contributors": [
-  	"Tom Atkinson <atkinson.tommy@neosoft.ba>"
+  	"Tom Atkinson <atkinson.tommy@neosoft.ba>",
+	"Kris Reeves <krisreeves@searchfanatics.com>"
   ],
   "main": "index.js",
   "engines": {
@@ -19,7 +20,7 @@
   	"mysql": ">=0.9.5"
   },
   "bugs": {
-  	"url": "https://github.com/bminer/node-mysql-queues/issues"
+  	"url": "https://github.com/myndzi/node-mysql-queues/issues"
   },
   "devDependencies": {},
   "keywords": [


### PR DESCRIPTION
You can use this if you like, please check my logic :)

The auto-commit was committing when it shouldn't, something like: add to queue in callback
of a query executed after .commit was called. It was messy, but upon consideration it seems
that the auto-commit functionality is unnecessary anyway. Consider:
1) Auto-commit is only enabled when the user calls .commit
2) Auto-commit is only enacted when the user creates a new Queue
3) New Queues do not become active when they are created
4) New Queues will not become active until the active queue is completed
5) The active queue does not complete until you call .commit or .rollback

The only case where auto-commit makes sense is if a user calls .commit and then
tries to begin a new transaction on the old Queue object... but this is not supported
since the Queue object does not have a .startTransaction method.

This fix enabled some code that otherwise failed, consisting of parallel multiple inserts,
all tests pass.
